### PR TITLE
fetch_devices

### DIFF
--- a/fetch_devices
+++ b/fetch_devices
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+DISK_PATTERN='^[a-z][a-z][a-z][0-9]+|^mmcblk[0-9]p[0-9]+|xvd[a-z][0-9]+'
+
 devices() {
   find /sys/block/*/ -name dev |
   grep -Ev '\/(ram|ramzswap|loop|zram|sr)[0-9][0-9]*\/'| tr [!] [/] |
@@ -20,8 +23,8 @@ REMOVABLES=$(dmesg | grep "removable disk" | cut -d : -f 5- | awk '{print $1}' |
 while getopts pd OPTION
 do
   case ${OPTION} in
-    p|P) devices | grep -E '^[a-z][a-z][a-z][0-9][0-9]*|^mmcblk[0-9]p[0-9][0-9]*' ;;
-    d|D) devices | grep -Ev '^[a-z][a-z][a-z][0-9][0-9]*|^mmcblk[0-9]p[0-9][0-9]*' ;;
+    p|P) devices | grep -E $DISK_PATTERN ;;
+    d|D) devices | grep -Ev $DISK_PATTERN ;;
     *) devices
   esac
 done


### PR DESCRIPTION
- Add support for disk types used in para-virtualised environments (such as Citrix) with xvd* disks
- Moved disk pattern out to variable since they are the same between disks and partitions (the former uses it to exclude the latter)
- Changed pattern to make use of "one or more" quantifiers that busybox grep now supports